### PR TITLE
Pool reporting improvements

### DIFF
--- a/Db/src/main/java/org/gusdb/fgputil/db/leakmonitor/UnclosedObjectInfo.java
+++ b/Db/src/main/java/org/gusdb/fgputil/db/leakmonitor/UnclosedObjectInfo.java
@@ -7,12 +7,14 @@ import java.util.Map;
 
 import org.gusdb.fgputil.EncryptionUtil;
 import org.gusdb.fgputil.FormatUtil;
+import org.gusdb.fgputil.logging.ThreadLocalLoggingVars;
 
 public class UnclosedObjectInfo {
 
   private String _dbName;
   private CloseableObjectType<?> _type;
   private Date _timeOpened;
+  private String _requestId;
   private String _stackTrace;
   private String _stackTraceHash;
 
@@ -24,6 +26,7 @@ public class UnclosedObjectInfo {
     _dbName = dbName;
     _type = type;
     _timeOpened = new Date();
+    _requestId = ThreadLocalLoggingVars.getRequestId();
     _stackTrace = FormatUtil.getCurrentStackTrace();
     _stackTraceHash = EncryptionUtil.encrypt(_stackTrace);
     // only add stack trace to global map if specified
@@ -43,11 +46,13 @@ public class UnclosedObjectInfo {
   public String getBasicInfo() {
     String timeOpenedStr = FormatUtil.formatDateTime(_timeOpened);
     double secondsOpen = ((double)(new Date().getTime() - _timeOpened.getTime())) / 1000;
+    String requestIdStr = _requestId == null ? "" : " during request with ID " + _requestId;
     return new StringBuilder()
         .append(_type)
         .append(" for ").append(_dbName)
         .append(", open for ").append(secondsOpen)
         .append(" seconds, retrieved from pool at ").append(timeOpenedStr)
+        .append(requestIdStr)
         .toString();
   }
 

--- a/Db/src/main/java/org/gusdb/fgputil/db/wrapper/DataSourceWrapper.java
+++ b/Db/src/main/java/org/gusdb/fgputil/db/wrapper/DataSourceWrapper.java
@@ -2,38 +2,80 @@ package org.gusdb.fgputil.db.wrapper;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.NoSuchElementException;
 
 import javax.sql.DataSource;
 
+import org.apache.log4j.Logger;
 import org.gusdb.fgputil.db.leakmonitor.CloseableObjectType;
 import org.gusdb.fgputil.db.leakmonitor.UnclosedObjectMonitor;
 import org.gusdb.fgputil.db.leakmonitor.UnclosedObjectMonitor.UnclosedObjectMonitorMap;
 import org.gusdb.fgputil.db.pool.ConnectionPoolConfig;
+import org.gusdb.fgputil.functional.FunctionalInterfaces.SupplierWithException;
 
 public class DataSourceWrapper extends AbstractDataSourceWrapper {
 
+  private static final Logger LOG = Logger.getLogger(DataSourceWrapper.class);
+
+  private static final String IDLE_OBJECT_MESSAGE = "Timeout waiting for idle object";
+
+  private final String _dbName;
   private final ConnectionPoolConfig _dbConfig;
   private final UnclosedObjectMonitorMap _unclosedObjectMonitorMap;
+  private final boolean _dumpStackTracesOnPoolExhaustion;
 
   public DataSourceWrapper(String dbName, DataSource underlyingDataSource, ConnectionPoolConfig dbConfig) {
-    this(dbName, underlyingDataSource, dbConfig, false);
+    this(dbName, underlyingDataSource, dbConfig, false, true);
   }
 
   public DataSourceWrapper(String dbName, DataSource underlyingDataSource,
-      ConnectionPoolConfig dbConfig, boolean recordAllStacktraces) {
+      ConnectionPoolConfig dbConfig, boolean recordAllStacktraces, boolean dumpStackTracesOnPoolExhaustion) {
     super(underlyingDataSource);
+    _dbName = dbName;
     _dbConfig = dbConfig;
     _unclosedObjectMonitorMap = new UnclosedObjectMonitorMap(dbName, recordAllStacktraces);
+    _dumpStackTracesOnPoolExhaustion = dumpStackTracesOnPoolExhaustion;
   }
 
   @Override
   public Connection getConnection() throws SQLException {
-    return new ConnectionWrapper(super.getConnection(), _dbConfig, _unclosedObjectMonitorMap);
+    return checkExhaustedPool(() ->
+      new ConnectionWrapper(super.getConnection(), _dbConfig, _unclosedObjectMonitorMap));
   }
 
   @Override
   public Connection getConnection(String username, String password) throws SQLException {
-    return new ConnectionWrapper(super.getConnection(username, password), _dbConfig, _unclosedObjectMonitorMap);
+    return checkExhaustedPool(() ->
+      new ConnectionWrapper(super.getConnection(username, password), _dbConfig, _unclosedObjectMonitorMap));
+  }
+
+  private Connection checkExhaustedPool(SupplierWithException<Connection> connectionSupplier) throws SQLException {
+    try {
+      return connectionSupplier.get();
+    }
+    catch (SQLException e) {
+      if (_dumpStackTracesOnPoolExhaustion) {
+        // check if this exception is likely caused by pool exhaustion
+        Throwable cause = e.getCause();
+        if (cause != null &&
+            cause instanceof NoSuchElementException &&
+            IDLE_OBJECT_MESSAGE.equals(cause.getMessage())) {
+          // looks like connection pool is exhausted, causing a request failure
+          LOG.warn("\n\nUnable to retrieve a database connection from the pool for " + _dbName +
+              " before timeout.  This application may be under heavy load or there may be a " +
+              "connection leak.  Will dump open connection information, followed by the " +
+              "exception which triggered this message.\n\n" + dumpUnclosedObjectInfo() + "\n\n", e);
+        }
+      }
+      throw e;
+    }
+    catch (RuntimeException e) {
+      throw e;
+    }
+    catch (Exception e) {
+      // this should never happen
+      throw new RuntimeException(e);
+    }
   }
 
   private UnclosedObjectMonitor<Connection> getConnectionMonitor() {

--- a/Db/src/main/java/org/gusdb/fgputil/db/wrapper/DataSourceWrapper.java
+++ b/Db/src/main/java/org/gusdb/fgputil/db/wrapper/DataSourceWrapper.java
@@ -63,7 +63,7 @@ public class DataSourceWrapper extends AbstractDataSourceWrapper {
           // looks like connection pool is exhausted, causing a request failure
           LOG.warn("\n\nUnable to retrieve a database connection from the pool for " + _dbName +
               " before timeout.  This application may be under heavy load or there may be a " +
-              "connection leak.  Will dump open connection information, followed by the " +
+              "connection leak.  Dumping open connection information, followed by the " +
               "exception which triggered this message.\n\n" + dumpUnclosedObjectInfo() + "\n\n", e);
         }
       }


### PR DESCRIPTION
Added request ID to logging when available and now dump stack traces when we get a NoSuchElementException on idle connection requests.