### PR TITLE
Parallelize deserialization in dual buffer reader

### DIFF
--- a/Core/src/main/java/org/gusdb/fgputil/DualBufferBinaryRecordReader.java
+++ b/Core/src/main/java/org/gusdb/fgputil/DualBufferBinaryRecordReader.java
@@ -184,9 +184,9 @@ public class DualBufferBinaryRecordReader<T> implements OptionStream<T>, AutoClo
             throw new RuntimeException(e);
           }
         }
+        _deserializedRecordsConsumed++;
       }
       final T element = (T) _deserializedElements[_deserializedRecordsConsumed];
-      _deserializedRecordsConsumed++;
       return Optional.of(element);
     }
 
@@ -225,7 +225,7 @@ public class DualBufferBinaryRecordReader<T> implements OptionStream<T>, AutoClo
       });
 
       bufferFill.thenAcceptAsync((channelReadResult) -> {
-        for (int i = 0; i < this._recordsReadFromDiskCount; ++i) {
+        for (int i = 0; i < this._recordsReadFromDiskCount; i++) {
           _deserializedElements[i] = this._deserializer.apply(channelReadResult._byteBuffer);
           // Lock while we increment the counter indicating available elements. The consumer will check if elements are
           // available and block if not so we need to ensure the count is consistent.

--- a/Core/src/main/java/org/gusdb/fgputil/FormatUtil.java
+++ b/Core/src/main/java/org/gusdb/fgputil/FormatUtil.java
@@ -9,6 +9,8 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.text.DecimalFormat;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
@@ -36,7 +38,7 @@ public class FormatUtil {
 
   public static final String NL = System.lineSeparator();
   public static final String TAB = "\t";
-  public static final String UTF8_ENCODING = "UTF-8";
+  public static final Charset UTF8_ENCODING = StandardCharsets.UTF_8;
 
   // standard formats in java.time
   public static final DateTimeFormatter STANDARD_DATE_FORMAT = DateTimeFormatter.ISO_LOCAL_DATE;
@@ -135,45 +137,21 @@ public class FormatUtil {
   }
 
   public static byte[] getUtf8EncodedBytes(String s) {
-    try {
-      return s.getBytes(UTF8_ENCODING);
-    }
-    catch (UnsupportedEncodingException e) {
-      // this should never happen; if it does, wrap in RuntimeException
-      throw new RuntimeException(UTF8_ENCODING + " encoding no longer supported by Java.", e);
-    }
+    return s.getBytes(UTF8_ENCODING);
   }
 
   public static String decodeUtf8EncodedBytes(byte[] bytes) {
-    try {
-      return new String(bytes, UTF8_ENCODING);
-    }
-    catch (UnsupportedEncodingException e) {
-      // this should never happen; if it does, wrap in RuntimeException
-      throw new RuntimeException(UTF8_ENCODING + " encoding no longer supported by Java.", e);
-    }
+    return new String(bytes, UTF8_ENCODING);
   }
 
   public static String urlEncodeUtf8(String s) {
-    try {
-      if (s == null) return null;
-      return URLEncoder.encode(s, UTF8_ENCODING);
-    }
-    catch (UnsupportedEncodingException e) {
-      // this should never happen; if it does, wrap in RuntimeException
-      throw new RuntimeException(UTF8_ENCODING + " encoding no longer supported by Java.", e);
-    }
+    if (s == null) return null;
+    return URLEncoder.encode(s, UTF8_ENCODING);
   }
 
   public static String urlDecodeUtf8(String s) {
-    try {
-      if (s == null) return null;
-      return URLDecoder.decode(s, UTF8_ENCODING);
-    }
-    catch (UnsupportedEncodingException e) {
-      // this should never happen; if it does, wrap in RuntimeException
-      throw new RuntimeException(UTF8_ENCODING + " encoding no longer supported by Java.", e);
-    }
+    if (s == null) return null;
+    return URLDecoder.decode(s, UTF8_ENCODING);
   }
 
   /**

--- a/Core/src/test/java/org/gusdb/fgputil/DualBufferBinaryRecordReaderTest.java
+++ b/Core/src/test/java/org/gusdb/fgputil/DualBufferBinaryRecordReaderTest.java
@@ -13,6 +13,7 @@ import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.UUID;
+import java.util.concurrent.Executors;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -96,7 +97,8 @@ public class DualBufferBinaryRecordReaderTest {
 
   // next read the records back out
   private void doTest(int recordsPerBuffer) throws IOException {
-    try (DualBufferBinaryRecordReader<Record> reader = new DualBufferBinaryRecordReader<>(Paths.get(FILE), Record.BINARY_SIZE, recordsPerBuffer, Record::new)) {
+    try (DualBufferBinaryRecordReader<Record> reader = new DualBufferBinaryRecordReader<>(Paths.get(FILE), Record.BINARY_SIZE, recordsPerBuffer, Record::new,
+            Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor())) {
       int i = 0;
       for (Record r : toIterable(toIterator(reader))) {
         assertEquals(i, r.i);

--- a/Core/src/test/java/org/gusdb/fgputil/DualBufferBinaryRecordReaderTest.java
+++ b/Core/src/test/java/org/gusdb/fgputil/DualBufferBinaryRecordReaderTest.java
@@ -92,7 +92,7 @@ public class DualBufferBinaryRecordReaderTest {
   public void doTestWithOffsetBufferSize() throws IOException {
     doTest(33);
   }
-  
+
 
   // next read the records back out
   private void doTest(int recordsPerBuffer) throws IOException {

--- a/Core/src/test/java/org/gusdb/fgputil/DualBufferBinaryRecordReaderTest.java
+++ b/Core/src/test/java/org/gusdb/fgputil/DualBufferBinaryRecordReaderTest.java
@@ -93,11 +93,18 @@ public class DualBufferBinaryRecordReaderTest {
     doTest(33);
   }
 
+  @Test
+  public void doTestWithOffsetBufferSizes() throws IOException {
+    doTest(4);
+  }
+
+
   // next read the records back out
   private void doTest(int recordsPerBuffer) throws IOException {
     try (DualBufferBinaryRecordReader<Record> reader = new DualBufferBinaryRecordReader<>(Paths.get(FILE), Record.BINARY_SIZE, recordsPerBuffer, Record::new)) {
       int i = 0;
       for (Record r : toIterable(toIterator(reader))) {
+//        System.out.println(i);
         assertEquals(i, r.i);
         assertEquals(i, r.l);
         assertEquals(i, r.f, 0.0001);

--- a/Core/src/test/java/org/gusdb/fgputil/DualBufferBinaryRecordReaderTest.java
+++ b/Core/src/test/java/org/gusdb/fgputil/DualBufferBinaryRecordReaderTest.java
@@ -92,19 +92,13 @@ public class DualBufferBinaryRecordReaderTest {
   public void doTestWithOffsetBufferSize() throws IOException {
     doTest(33);
   }
-
-  @Test
-  public void doTestWithOffsetBufferSizes() throws IOException {
-    doTest(4);
-  }
-
+  
 
   // next read the records back out
   private void doTest(int recordsPerBuffer) throws IOException {
     try (DualBufferBinaryRecordReader<Record> reader = new DualBufferBinaryRecordReader<>(Paths.get(FILE), Record.BINARY_SIZE, recordsPerBuffer, Record::new)) {
       int i = 0;
       for (Record r : toIterable(toIterator(reader))) {
-//        System.out.println(i);
         assertEquals(i, r.i);
         assertEquals(i, r.l);
         assertEquals(i, r.f, 0.0001);


### PR DESCRIPTION
## Overview
Parallelizing deserialization of data. This adds distinct thread pools for deserialization and reading from disk.

We may be able to slightly increase the pool size for deserialization depending on cores available.

## Testing
Ran performance testing and regression testing.

