### PR TITLE
Timeouts on SQL connections in SQLRunner

### DIFF
--- a/Db/src/main/java/org/gusdb/fgputil/db/runner/SQLRunner.java
+++ b/Db/src/main/java/org/gusdb/fgputil/db/runner/SQLRunner.java
@@ -202,24 +202,25 @@ public class SQLRunner {
   }
 
   /**
-   * Set a global connection timeout that gets used for all SQLRunner instances if no override is set. Set to null
+   * Set a global default connection timeout that gets used for all SQLRunner instances if no override is set. Set to null
    * if no global default timeout is desired.
    *
    * @param timeout Default timeout value.
    */
-  public static void setGlobalDefaultConnectionTimeout(Duration timeout) {
+  public static void setDefaultConnectionTimeout(Duration timeout) {
     GLOBAL_QUERY_TIMEOUT_SECONDS = Optional.ofNullable(timeout)
         .map(d -> (int) d.getSeconds())
         .orElse(null);
   }
 
   /**
-   * Set the override connection timeout for this instance of SQLRunner. This takes precedence of the global timeout.
+   * Set the connection timeout for this instance of SQLRunner. This takes precedence over the default timeout set via
+   * {@link this#setDefaultConnectionTimeout(Duration)}.
    *
    * @param timeout Timeout value to propagate to JDBC statement.
    * @return this instance of SQLRunner.
    */
-  public SQLRunner setDefaultConnectionTimeout(Duration timeout) {
+  public SQLRunner setConnectionTimeout(Duration timeout) {
     _timeout = timeout;
     return this;
   }

--- a/Db/src/main/java/org/gusdb/fgputil/db/runner/SQLRunner.java
+++ b/Db/src/main/java/org/gusdb/fgputil/db/runner/SQLRunner.java
@@ -32,8 +32,8 @@ public class SQLRunner {
 
   private static Logger LOG = Logger.getLogger(SQLRunner.class.getName());
 
-  // Set a long global timeout to avoid connection leaks when the database hangs.
-  private static Integer GLOBAL_QUERY_TIMEOUT_SECONDS = 1800;
+  // Set a long default static timeout to avoid connection leaks if the database hangs.
+  private static Integer DEFAULT_QUERY_TIMEOUT_SECONDS = 1800;
 
   /**
    * Represents a class that will handle the ResultSet when caller uses it with
@@ -208,7 +208,7 @@ public class SQLRunner {
    * @param timeout Default timeout value.
    */
   public static void setDefaultConnectionTimeout(Duration timeout) {
-    GLOBAL_QUERY_TIMEOUT_SECONDS = Optional.ofNullable(timeout)
+    DEFAULT_QUERY_TIMEOUT_SECONDS = Optional.ofNullable(timeout)
         .map(d -> (int) d.getSeconds())
         .orElse(null);
   }
@@ -396,8 +396,8 @@ public class SQLRunner {
       stmt = conn.prepareStatement(_sql);
 
       // Prioritize override query timeout and fallback to global query timeout.
-      if (GLOBAL_QUERY_TIMEOUT_SECONDS != null) {
-        stmt.setQueryTimeout(GLOBAL_QUERY_TIMEOUT_SECONDS);
+      if (DEFAULT_QUERY_TIMEOUT_SECONDS != null) {
+        stmt.setQueryTimeout(DEFAULT_QUERY_TIMEOUT_SECONDS);
       }
       if (_timeout != null) {
         stmt.setQueryTimeout((int) _timeout.getSeconds());

--- a/Db/src/main/java/org/gusdb/fgputil/db/runner/SQLRunner.java
+++ b/Db/src/main/java/org/gusdb/fgputil/db/runner/SQLRunner.java
@@ -7,6 +7,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.Duration;
+import java.util.Optional;
 
 import javax.sql.DataSource;
 
@@ -30,7 +31,9 @@ import org.gusdb.fgputil.db.slowquery.SqlTimer;
 public class SQLRunner {
 
   private static Logger LOG = Logger.getLogger(SQLRunner.class.getName());
-  private static Integer GLOBAL_QUERY_TIMEOUT_SECONDS = null;
+
+  // Set a long global timeout to avoid connection leaks when the database hangs.
+  private static Integer GLOBAL_QUERY_TIMEOUT_SECONDS = 1800;
 
   /**
    * Represents a class that will handle the ResultSet when caller uses it with
@@ -199,12 +202,15 @@ public class SQLRunner {
   }
 
   /**
-   * Set a global connection timeout that gets used for all SQLRunner instances if no override is set.
+   * Set a global connection timeout that gets used for all SQLRunner instances if no override is set. Set to null
+   * if no global default timeout is desired.
    *
    * @param timeout Default timeout value.
    */
   public static void setGlobalDefaultConnectionTimeout(Duration timeout) {
-    GLOBAL_QUERY_TIMEOUT_SECONDS = (int) timeout.getSeconds();
+    GLOBAL_QUERY_TIMEOUT_SECONDS = Optional.ofNullable(timeout)
+        .map(d -> (int) d.getSeconds())
+        .orElse(null);
   }
 
   /**


### PR DESCRIPTION
## Overview
Add a timeout to SQLRunner. Follow up from: https://github.com/VEuPathDB/EdaSubsettingService/issues/132