### PR TITLE
Fix message check when connection pool is exhausted

### DIFF
--- a/Db/src/main/java/org/gusdb/fgputil/db/wrapper/DataSourceWrapper.java
+++ b/Db/src/main/java/org/gusdb/fgputil/db/wrapper/DataSourceWrapper.java
@@ -59,7 +59,8 @@ public class DataSourceWrapper extends AbstractDataSourceWrapper {
         Throwable cause = e.getCause();
         if (cause != null &&
             cause instanceof NoSuchElementException &&
-            IDLE_OBJECT_MESSAGE.equals(cause.getMessage())) {
+            cause.getMessage() != null &&
+            cause.getMessage().startsWith(IDLE_OBJECT_MESSAGE)) {
           // looks like connection pool is exhausted, causing a request failure
           LOG.warn("\n\nUnable to retrieve a database connection from the pool for " + _dbName +
               " before timeout.  This application may be under heavy load or there may be a " +


### PR DESCRIPTION
## Overview
We've been having some issues in EDA with connection pool exhaustion. I think I have a fix, but I noticed we're not getting the connection dump and I think it's because of a slight mismatch in the exception message we're looking for.

Message in the logs:
```
Caused by: java.util.NoSuchElementException: Timeout waiting for idle object, borrowMaxWaitDuration=PT0.05S
```