### PR TITLE
Backport to Java 11 + Tomcat 6 (live sites due to be replaced)

### DIFF
--- a/Cache/pom.xml
+++ b/Cache/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.6-legacy</version>
+    <version>3.2.7-legacy-SNAPSHOT</version>
   </parent>
 
   <name>Functional Genomics Platform - Cache</name>

--- a/Cache/pom.xml
+++ b/Cache/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.4-legacy-SNAPSHOT</version>
+    <version>3.2.4-legacy</version>
   </parent>
 
   <name>Functional Genomics Platform - Cache</name>

--- a/Cache/pom.xml
+++ b/Cache/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.5-legacy</version>
+    <version>3.2.6-legacy-SNAPSHOT</version>
   </parent>
 
   <name>Functional Genomics Platform - Cache</name>

--- a/Cache/pom.xml
+++ b/Cache/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.4-legacy</version>
+    <version>3.2.5-legacy-SNAPSHOT</version>
   </parent>
 
   <name>Functional Genomics Platform - Cache</name>

--- a/Cache/pom.xml
+++ b/Cache/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.6-legacy-SNAPSHOT</version>
+    <version>3.2.6-legacy</version>
   </parent>
 
   <name>Functional Genomics Platform - Cache</name>

--- a/Cache/pom.xml
+++ b/Cache/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.5-SNAPSHOT</version>
+    <version>3.2.4-legacy-SNAPSHOT</version>
   </parent>
 
   <name>Functional Genomics Platform - Cache</name>

--- a/Cache/pom.xml
+++ b/Cache/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.5-legacy-SNAPSHOT</version>
+    <version>3.2.5-legacy</version>
   </parent>
 
   <name>Functional Genomics Platform - Cache</name>

--- a/Cache/src/main/java/org/gusdb/fgputil/cache/disk/OnDiskCache.java
+++ b/Cache/src/main/java/org/gusdb/fgputil/cache/disk/OnDiskCache.java
@@ -1,6 +1,5 @@
 package org.gusdb.fgputil.cache.disk;
 
-import static org.gusdb.fgputil.IoUtil.createOpenPermsDirectory;
 import static org.gusdb.fgputil.functional.Functions.mapException;
 
 import java.io.IOException;
@@ -14,10 +13,9 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import org.gusdb.fgputil.IoUtil;
+import org.gusdb.fgputil.cache.disk.DirectoryLock.DirectoryLockTimeoutException;
 import org.gusdb.fgputil.functional.FunctionalInterfaces.ConsumerWithException;
 import org.gusdb.fgputil.functional.FunctionalInterfaces.FunctionWithException;
-
-import org.gusdb.fgputil.cache.disk.DirectoryLock.DirectoryLockTimeoutException;
 
 /**
  * Manages a filesystem-based cache of entries, with data located specified directory
@@ -182,8 +180,7 @@ public class OnDiskCache {
 
     // determine path to entry directory and ensure existence (atomic)
     Path path = getEntryPath(cacheKey);
-    mapException(() -> createOpenPermsDirectory(path, true),
-        e -> new RuntimeException("Could not create disk cache entry directory " + path, e));
+    IoUtil.ensureCreation(Files::createDirectory, path);
 
     // get a lock on this entry
     try (DirectoryLock lock = new DirectoryLock(path, lockTimeoutMillisOverride, _lockPollFrequencyMillis)) {

--- a/Cli/pom.xml
+++ b/Cli/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.4-legacy</version>
+    <version>3.2.5-legacy-SNAPSHOT</version>
   </parent>
 
   <name>Functional Genomics Platform - CLI</name>

--- a/Cli/pom.xml
+++ b/Cli/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.5-SNAPSHOT</version>
+    <version>3.2.4-legacy-SNAPSHOT</version>
   </parent>
 
   <name>Functional Genomics Platform - CLI</name>

--- a/Cli/pom.xml
+++ b/Cli/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.6-legacy</version>
+    <version>3.2.7-legacy-SNAPSHOT</version>
   </parent>
 
   <name>Functional Genomics Platform - CLI</name>

--- a/Cli/pom.xml
+++ b/Cli/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.4-legacy-SNAPSHOT</version>
+    <version>3.2.4-legacy</version>
   </parent>
 
   <name>Functional Genomics Platform - CLI</name>

--- a/Cli/pom.xml
+++ b/Cli/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.6-legacy-SNAPSHOT</version>
+    <version>3.2.6-legacy</version>
   </parent>
 
   <name>Functional Genomics Platform - CLI</name>

--- a/Cli/pom.xml
+++ b/Cli/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.5-legacy</version>
+    <version>3.2.6-legacy-SNAPSHOT</version>
   </parent>
 
   <name>Functional Genomics Platform - CLI</name>

--- a/Cli/pom.xml
+++ b/Cli/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.5-legacy-SNAPSHOT</version>
+    <version>3.2.5-legacy</version>
   </parent>
 
   <name>Functional Genomics Platform - CLI</name>

--- a/Cli/src/main/java/org/gusdb/fgputil/CliUtil.java
+++ b/Cli/src/main/java/org/gusdb/fgputil/CliUtil.java
@@ -1,14 +1,12 @@
 package org.gusdb.fgputil;
 
-import java.io.IOException;
-
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.apache.commons.cli.help.HelpFormatter;
 
 public class CliUtil {
 
@@ -59,12 +57,7 @@ public class CliUtil {
   }
 
   public static void printHelp(String cmdlineSyntax, String header, Options options, String footer) {
-    try {
-      HelpFormatter formatter = HelpFormatter.builder().get();
-      formatter.printHelp(cmdlineSyntax, header, options, footer, false);
-    }
-    catch (IOException e) {
-      throw new RuntimeException("Unable to print help", e);
-    }
+    HelpFormatter formatter = HelpFormatter.builder().get();
+    formatter.printHelp(cmdlineSyntax, header, options, footer, false);
   }
 }

--- a/Client/pom.xml
+++ b/Client/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.5-SNAPSHOT</version>
+    <version>3.2.4-legacy-SNAPSHOT</version>
   </parent>
 
   <name>Functional Genomics Platform - Client</name>

--- a/Client/pom.xml
+++ b/Client/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.6-legacy-SNAPSHOT</version>
+    <version>3.2.6-legacy</version>
   </parent>
 
   <name>Functional Genomics Platform - Client</name>

--- a/Client/pom.xml
+++ b/Client/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.4-legacy-SNAPSHOT</version>
+    <version>3.2.4-legacy</version>
   </parent>
 
   <name>Functional Genomics Platform - Client</name>

--- a/Client/pom.xml
+++ b/Client/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.5-legacy</version>
+    <version>3.2.6-legacy-SNAPSHOT</version>
   </parent>
 
   <name>Functional Genomics Platform - Client</name>

--- a/Client/pom.xml
+++ b/Client/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.5-legacy-SNAPSHOT</version>
+    <version>3.2.5-legacy</version>
   </parent>
 
   <name>Functional Genomics Platform - Client</name>

--- a/Client/pom.xml
+++ b/Client/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.6-legacy</version>
+    <version>3.2.7-legacy-SNAPSHOT</version>
   </parent>
 
   <name>Functional Genomics Platform - Client</name>

--- a/Client/pom.xml
+++ b/Client/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.4-legacy</version>
+    <version>3.2.5-legacy-SNAPSHOT</version>
   </parent>
 
   <name>Functional Genomics Platform - Client</name>

--- a/Core/pom.xml
+++ b/Core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.5-SNAPSHOT</version>
+    <version>3.2.4-legacy-SNAPSHOT</version>
   </parent>
 
   <name>Functional Genomics Platform - Core</name>
@@ -73,7 +73,7 @@
 
     <dependency>
       <groupId>org.graalvm.js</groupId>
-      <artifactId>js-language</artifactId>
+      <artifactId>js</artifactId>
     </dependency>
     <dependency>
       <groupId>org.graalvm.js</groupId>

--- a/Core/pom.xml
+++ b/Core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.6-legacy-SNAPSHOT</version>
+    <version>3.2.6-legacy</version>
   </parent>
 
   <name>Functional Genomics Platform - Core</name>

--- a/Core/pom.xml
+++ b/Core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.4-legacy</version>
+    <version>3.2.5-legacy-SNAPSHOT</version>
   </parent>
 
   <name>Functional Genomics Platform - Core</name>

--- a/Core/pom.xml
+++ b/Core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.4-legacy-SNAPSHOT</version>
+    <version>3.2.4-legacy</version>
   </parent>
 
   <name>Functional Genomics Platform - Core</name>

--- a/Core/pom.xml
+++ b/Core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.5-legacy</version>
+    <version>3.2.6-legacy-SNAPSHOT</version>
   </parent>
 
   <name>Functional Genomics Platform - Core</name>

--- a/Core/pom.xml
+++ b/Core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.6-legacy</version>
+    <version>3.2.7-legacy-SNAPSHOT</version>
   </parent>
 
   <name>Functional Genomics Platform - Core</name>

--- a/Core/pom.xml
+++ b/Core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.5-legacy-SNAPSHOT</version>
+    <version>3.2.5-legacy</version>
   </parent>
 
   <name>Functional Genomics Platform - Core</name>

--- a/Core/src/main/java/org/gusdb/fgputil/FormatUtil.java
+++ b/Core/src/main/java/org/gusdb/fgputil/FormatUtil.java
@@ -156,17 +156,18 @@ public class FormatUtil {
   /**
    * Attempts to convert the given text into HTML, replacing special characters
    * with their HTML equivalents.
-   * TODO: this method should be improved!
    *
    * @param str string to convert
    * @return converted string
    */
   public static String escapeHtml(String str) {
     return str
-      .replaceAll("&", "&amp;")
-      .replaceAll("<", "&lt;")
-      .replaceAll(">", "&gt;")
-      .replaceAll("\n", "<br/>\n");
+      .replace("&", "&amp;")
+      .replace("<", "&lt;")
+      .replace(">", "&gt;")
+      .replace("\"", "&quot;")
+      .replace("'", "&#39;")
+      .replace("\n", "<br/>\n");
   }
 
   public static String splitCamelCase(String s) {

--- a/Core/src/main/java/org/gusdb/fgputil/IoUtil.java
+++ b/Core/src/main/java/org/gusdb/fgputil/IoUtil.java
@@ -31,6 +31,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.apache.log4j.Logger;
+import org.gusdb.fgputil.functional.FunctionalInterfaces.BiFunctionWithException;
 
 public class IoUtil {
 
@@ -536,4 +537,63 @@ public class IoUtil {
     }
   }
 
+  // TODO: The utils below duplicate functionality of the utils above.  Develop a reasonable API
+  //    to cover our use cases and consolidate these into a set of reasonable functions.
+
+  // use different default permissions for dirs and files
+  private static final String DEFAULT_POSIX_PERMS_DIR = "rwxrwxr-x";
+  private static final String DEFAULT_POSIX_PERMS_FILE = "rw-rw-r--";
+
+  private static Set<PosixFilePermission> getDefaultPerms(Path path) {
+    return PosixFilePermissions.fromString(Files.isDirectory(path)
+        ? DEFAULT_POSIX_PERMS_DIR
+        : DEFAULT_POSIX_PERMS_FILE);
+  }
+
+  /**
+   * Creates a new filesystem object (file or directory) with shared group write but only all-read perms aka "rwxrwxr-x"
+   * Meant to be called with either Files::createFile or Files::createDirectory.
+   */
+  public static void ensureCreation(BiFunctionWithException<Path, FileAttribute<?>[], Path> creationFunction, Path path) {
+    try {
+      creationFunction.apply(path, new FileAttribute[] {
+          PosixFilePermissions.asFileAttribute(getDefaultPerms(path))
+      });
+      tryToOpenGroupPerms(path);
+    }
+    catch (FileAlreadyExistsException e) {
+      // this is ok; try to ensure perms on existing directory (may fail if not owned by us)
+      tryToOpenGroupPerms(path);
+    }
+    catch (Exception e) {
+      // any other exception is a problem
+      throw new RuntimeException("Could not create path " + path.toAbsolutePath(), e);
+    }
+  }
+
+  public static void tryToOpenGroupPerms(Path path) {
+    try {
+      // get the current permissions
+      Set<PosixFilePermission> currentPerms = Files.getPosixFilePermissions(path);
+      Set<PosixFilePermission> targetPerms = getDefaultPerms(path);
+
+      // if any desired permission is missing from the current perms, then try to add
+      for (PosixFilePermission perm : targetPerms) {
+        if (!currentPerms.contains(perm)) {
+          // union the current perms with the defaults so we don't inadvertently remove permissions already granted
+          targetPerms.addAll(currentPerms);
+          Files.setPosixFilePermissions(path, targetPerms);
+          return;
+        }
+      }
+    }
+    catch (UnsupportedOperationException e) {
+      // log but ignore it since it's not supported on Windows
+      LOG.warn("Cannot set permissions to " + path, e);
+    }
+    catch (IOException e) {
+      // log but ignore since sometimes existing creation is not owned by us or system perms is enough
+      LOG.warn("Cannot set permissions to " + path, e);
+    }
+  }
 }

--- a/Core/src/main/java/org/gusdb/fgputil/runtime/RuntimeUtil.java
+++ b/Core/src/main/java/org/gusdb/fgputil/runtime/RuntimeUtil.java
@@ -86,7 +86,7 @@ public class RuntimeUtil {
 
       // if stdout file is passed, write stdout to the file; otherwise merge with stderr
       if (stdoutFile.isPresent())
-        processBuilder.redirectInput(stdoutFile.get());
+        processBuilder.redirectOutput(stdoutFile.get());
       else
         processBuilder.redirectErrorStream(true);
 

--- a/Core/src/test/java/org/gusdb/fgputil/SubprocessTest.java
+++ b/Core/src/test/java/org/gusdb/fgputil/SubprocessTest.java
@@ -1,0 +1,69 @@
+package org.gusdb.fgputil;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.gusdb.fgputil.runtime.RuntimeUtil;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SubprocessTest {
+
+  @Test
+  public void testSubprocessOutputCapture() {
+    StringBuilder out = new StringBuilder();
+    RuntimeUtil.executeSubprocess(
+        List.of("/usr/bin/echo", "hello1"),
+        Collections.emptyMap(),
+        Optional.empty(),
+        str -> out.append(str),
+        Optional.empty(),
+        Optional.of(Duration.of(10, ChronoUnit.SECONDS))
+    );
+    Assert.assertEquals("hello1", out.toString());
+  }
+
+  @Test
+  public void testStdoutAndStdinFileRedirect() throws IOException {
+
+    File tmpFile = null;
+    try {
+      tmpFile= File.createTempFile("subprocessTest-", ".txt");
+      System.out.println("Will use temporary file " + tmpFile);
+
+      // 1. run program to write stdout to output file
+      RuntimeUtil.executeSubprocess(
+          List.of("echo", "hello"),
+          Collections.emptyMap(),
+          Optional.empty(),
+          str -> System.err.println("subprocess stderr: " + str),
+          Optional.of(tmpFile),
+          Optional.of(Duration.of(10, ChronoUnit.SECONDS))
+      );
+      Assert.assertTrue(Files.isRegularFile(tmpFile.toPath()));
+      Assert.assertEquals("hello", Files.readString(tmpFile.toPath()).trim());
+
+      // 2. run program to read output file as stdin
+      StringBuilder out = new StringBuilder();
+      RuntimeUtil.executeSubprocess(
+          List.of("perl", "-ne", "print;"),
+          Collections.emptyMap(),
+          Optional.of(tmpFile),
+          str -> out.append(str),
+          Optional.empty(),
+          Optional.of(Duration.of(10, ChronoUnit.SECONDS))
+      );
+      Assert.assertEquals("hello", out.toString());
+    }
+    finally {
+      if (tmpFile != null)
+        Files.delete(tmpFile.toPath());
+    }
+  }
+}

--- a/Db/pom.xml
+++ b/Db/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.4-legacy-SNAPSHOT</version>
+    <version>3.2.4-legacy</version>
   </parent>
 
   <name>Functional Genomics Platform - Database</name>

--- a/Db/pom.xml
+++ b/Db/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.6-legacy</version>
+    <version>3.2.7-legacy-SNAPSHOT</version>
   </parent>
 
   <name>Functional Genomics Platform - Database</name>

--- a/Db/pom.xml
+++ b/Db/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.4-legacy</version>
+    <version>3.2.5-legacy-SNAPSHOT</version>
   </parent>
 
   <name>Functional Genomics Platform - Database</name>

--- a/Db/pom.xml
+++ b/Db/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.5-legacy</version>
+    <version>3.2.6-legacy-SNAPSHOT</version>
   </parent>
 
   <name>Functional Genomics Platform - Database</name>

--- a/Db/pom.xml
+++ b/Db/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.5-SNAPSHOT</version>
+    <version>3.2.4-legacy-SNAPSHOT</version>
   </parent>
 
   <name>Functional Genomics Platform - Database</name>

--- a/Db/pom.xml
+++ b/Db/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.5-legacy-SNAPSHOT</version>
+    <version>3.2.5-legacy</version>
   </parent>
 
   <name>Functional Genomics Platform - Database</name>

--- a/Db/pom.xml
+++ b/Db/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.6-legacy-SNAPSHOT</version>
+    <version>3.2.6-legacy</version>
   </parent>
 
   <name>Functional Genomics Platform - Database</name>

--- a/Events/pom.xml
+++ b/Events/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.4-legacy</version>
+    <version>3.2.5-legacy-SNAPSHOT</version>
   </parent>
   <name>Functional Genomics Platform - Events</name>
   <artifactId>fgputil-events</artifactId>

--- a/Events/pom.xml
+++ b/Events/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.6-legacy-SNAPSHOT</version>
+    <version>3.2.6-legacy</version>
   </parent>
   <name>Functional Genomics Platform - Events</name>
   <artifactId>fgputil-events</artifactId>

--- a/Events/pom.xml
+++ b/Events/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.5-legacy-SNAPSHOT</version>
+    <version>3.2.5-legacy</version>
   </parent>
   <name>Functional Genomics Platform - Events</name>
   <artifactId>fgputil-events</artifactId>

--- a/Events/pom.xml
+++ b/Events/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.4-legacy-SNAPSHOT</version>
+    <version>3.2.4-legacy</version>
   </parent>
   <name>Functional Genomics Platform - Events</name>
   <artifactId>fgputil-events</artifactId>

--- a/Events/pom.xml
+++ b/Events/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.5-SNAPSHOT</version>
+    <version>3.2.4-legacy-SNAPSHOT</version>
   </parent>
   <name>Functional Genomics Platform - Events</name>
   <artifactId>fgputil-events</artifactId>

--- a/Events/pom.xml
+++ b/Events/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.6-legacy</version>
+    <version>3.2.7-legacy-SNAPSHOT</version>
   </parent>
   <name>Functional Genomics Platform - Events</name>
   <artifactId>fgputil-events</artifactId>

--- a/Events/pom.xml
+++ b/Events/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.5-legacy</version>
+    <version>3.2.6-legacy-SNAPSHOT</version>
   </parent>
   <name>Functional Genomics Platform - Events</name>
   <artifactId>fgputil-events</artifactId>

--- a/Json/pom.xml
+++ b/Json/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.5-legacy-SNAPSHOT</version>
+    <version>3.2.5-legacy</version>
   </parent>
 
   <name>Functional Genomics Platform - JSON</name>

--- a/Json/pom.xml
+++ b/Json/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.4-legacy</version>
+    <version>3.2.5-legacy-SNAPSHOT</version>
   </parent>
 
   <name>Functional Genomics Platform - JSON</name>

--- a/Json/pom.xml
+++ b/Json/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.5-SNAPSHOT</version>
+    <version>3.2.4-legacy-SNAPSHOT</version>
   </parent>
 
   <name>Functional Genomics Platform - JSON</name>

--- a/Json/pom.xml
+++ b/Json/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.5-legacy</version>
+    <version>3.2.6-legacy-SNAPSHOT</version>
   </parent>
 
   <name>Functional Genomics Platform - JSON</name>

--- a/Json/pom.xml
+++ b/Json/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.6-legacy-SNAPSHOT</version>
+    <version>3.2.6-legacy</version>
   </parent>
 
   <name>Functional Genomics Platform - JSON</name>

--- a/Json/pom.xml
+++ b/Json/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.6-legacy</version>
+    <version>3.2.7-legacy-SNAPSHOT</version>
   </parent>
 
   <name>Functional Genomics Platform - JSON</name>

--- a/Json/pom.xml
+++ b/Json/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.4-legacy-SNAPSHOT</version>
+    <version>3.2.4-legacy</version>
   </parent>
 
   <name>Functional Genomics Platform - JSON</name>

--- a/Server/pom.xml
+++ b/Server/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.4-legacy</version>
+    <version>3.2.5-legacy-SNAPSHOT</version>
   </parent>
 
   <name>Functional Genomics Platform - REST Server</name>

--- a/Server/pom.xml
+++ b/Server/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.5-legacy-SNAPSHOT</version>
+    <version>3.2.5-legacy</version>
   </parent>
 
   <name>Functional Genomics Platform - REST Server</name>

--- a/Server/pom.xml
+++ b/Server/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.6-legacy-SNAPSHOT</version>
+    <version>3.2.6-legacy</version>
   </parent>
 
   <name>Functional Genomics Platform - REST Server</name>

--- a/Server/pom.xml
+++ b/Server/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.5-legacy</version>
+    <version>3.2.6-legacy-SNAPSHOT</version>
   </parent>
 
   <name>Functional Genomics Platform - REST Server</name>

--- a/Server/pom.xml
+++ b/Server/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.6-legacy</version>
+    <version>3.2.7-legacy-SNAPSHOT</version>
   </parent>
 
   <name>Functional Genomics Platform - REST Server</name>

--- a/Server/pom.xml
+++ b/Server/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.5-SNAPSHOT</version>
+    <version>3.2.4-legacy-SNAPSHOT</version>
   </parent>
 
   <name>Functional Genomics Platform - REST Server</name>

--- a/Server/pom.xml
+++ b/Server/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.4-legacy-SNAPSHOT</version>
+    <version>3.2.4-legacy</version>
   </parent>
 
   <name>Functional Genomics Platform - REST Server</name>

--- a/Servlet/pom.xml
+++ b/Servlet/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.5-legacy-SNAPSHOT</version>
+    <version>3.2.5-legacy</version>
   </parent>
 
   <name>Functional Genomics Platform - Servlet</name>

--- a/Servlet/pom.xml
+++ b/Servlet/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.5-SNAPSHOT</version>
+    <version>3.2.4-legacy-SNAPSHOT</version>
   </parent>
 
   <name>Functional Genomics Platform - Servlet</name>
@@ -20,7 +20,7 @@
 
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
+      <artifactId>servlet-api</artifactId>
       <scope>provided</scope>
     </dependency>
 

--- a/Servlet/pom.xml
+++ b/Servlet/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.4-legacy-SNAPSHOT</version>
+    <version>3.2.4-legacy</version>
   </parent>
 
   <name>Functional Genomics Platform - Servlet</name>

--- a/Servlet/pom.xml
+++ b/Servlet/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.6-legacy</version>
+    <version>3.2.7-legacy-SNAPSHOT</version>
   </parent>
 
   <name>Functional Genomics Platform - Servlet</name>

--- a/Servlet/pom.xml
+++ b/Servlet/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.4-legacy</version>
+    <version>3.2.5-legacy-SNAPSHOT</version>
   </parent>
 
   <name>Functional Genomics Platform - Servlet</name>

--- a/Servlet/pom.xml
+++ b/Servlet/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.5-legacy</version>
+    <version>3.2.6-legacy-SNAPSHOT</version>
   </parent>
 
   <name>Functional Genomics Platform - Servlet</name>

--- a/Servlet/pom.xml
+++ b/Servlet/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.6-legacy-SNAPSHOT</version>
+    <version>3.2.6-legacy</version>
   </parent>
 
   <name>Functional Genomics Platform - Servlet</name>

--- a/Solr/pom.xml
+++ b/Solr/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.4-legacy</version>
+    <version>3.2.5-legacy-SNAPSHOT</version>
   </parent>
 
   <name>Functional Genomics Platform - SOLR</name>

--- a/Solr/pom.xml
+++ b/Solr/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.5-SNAPSHOT</version>
+    <version>3.2.4-legacy-SNAPSHOT</version>
   </parent>
 
   <name>Functional Genomics Platform - SOLR</name>

--- a/Solr/pom.xml
+++ b/Solr/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.6-legacy-SNAPSHOT</version>
+    <version>3.2.6-legacy</version>
   </parent>
 
   <name>Functional Genomics Platform - SOLR</name>

--- a/Solr/pom.xml
+++ b/Solr/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.4-legacy-SNAPSHOT</version>
+    <version>3.2.4-legacy</version>
   </parent>
 
   <name>Functional Genomics Platform - SOLR</name>

--- a/Solr/pom.xml
+++ b/Solr/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.6-legacy</version>
+    <version>3.2.7-legacy-SNAPSHOT</version>
   </parent>
 
   <name>Functional Genomics Platform - SOLR</name>

--- a/Solr/pom.xml
+++ b/Solr/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.5-legacy-SNAPSHOT</version>
+    <version>3.2.5-legacy</version>
   </parent>
 
   <name>Functional Genomics Platform - SOLR</name>

--- a/Solr/pom.xml
+++ b/Solr/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.5-legacy</version>
+    <version>3.2.6-legacy-SNAPSHOT</version>
   </parent>
 
   <name>Functional Genomics Platform - SOLR</name>

--- a/Test/pom.xml
+++ b/Test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.6-legacy-SNAPSHOT</version>
+    <version>3.2.6-legacy</version>
   </parent>
 
   <name>Functional Genomics Platform - Test</name>

--- a/Test/pom.xml
+++ b/Test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.4-legacy</version>
+    <version>3.2.5-legacy-SNAPSHOT</version>
   </parent>
 
   <name>Functional Genomics Platform - Test</name>

--- a/Test/pom.xml
+++ b/Test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.5-legacy</version>
+    <version>3.2.6-legacy-SNAPSHOT</version>
   </parent>
 
   <name>Functional Genomics Platform - Test</name>

--- a/Test/pom.xml
+++ b/Test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.4-legacy-SNAPSHOT</version>
+    <version>3.2.4-legacy</version>
   </parent>
 
   <name>Functional Genomics Platform - Test</name>

--- a/Test/pom.xml
+++ b/Test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.6-legacy</version>
+    <version>3.2.7-legacy-SNAPSHOT</version>
   </parent>
 
   <name>Functional Genomics Platform - Test</name>

--- a/Test/pom.xml
+++ b/Test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.5-legacy-SNAPSHOT</version>
+    <version>3.2.5-legacy</version>
   </parent>
 
   <name>Functional Genomics Platform - Test</name>

--- a/Test/pom.xml
+++ b/Test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.5-SNAPSHOT</version>
+    <version>3.2.4-legacy-SNAPSHOT</version>
   </parent>
 
   <name>Functional Genomics Platform - Test</name>

--- a/Web/pom.xml
+++ b/Web/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.5-legacy</version>
+    <version>3.2.6-legacy-SNAPSHOT</version>
   </parent>
 
   <name>Functional Genomics Platform - Web</name>

--- a/Web/pom.xml
+++ b/Web/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.6-legacy</version>
+    <version>3.2.7-legacy-SNAPSHOT</version>
   </parent>
 
   <name>Functional Genomics Platform - Web</name>

--- a/Web/pom.xml
+++ b/Web/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.4-legacy-SNAPSHOT</version>
+    <version>3.2.4-legacy</version>
   </parent>
 
   <name>Functional Genomics Platform - Web</name>

--- a/Web/pom.xml
+++ b/Web/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.5-SNAPSHOT</version>
+    <version>3.2.4-legacy-SNAPSHOT</version>
   </parent>
 
   <name>Functional Genomics Platform - Web</name>

--- a/Web/pom.xml
+++ b/Web/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.5-legacy-SNAPSHOT</version>
+    <version>3.2.5-legacy</version>
   </parent>
 
   <name>Functional Genomics Platform - Web</name>

--- a/Web/pom.xml
+++ b/Web/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.6-legacy-SNAPSHOT</version>
+    <version>3.2.6-legacy</version>
   </parent>
 
   <name>Functional Genomics Platform - Web</name>

--- a/Web/pom.xml
+++ b/Web/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.4-legacy</version>
+    <version>3.2.5-legacy-SNAPSHOT</version>
   </parent>
 
   <name>Functional Genomics Platform - Web</name>

--- a/Xml/pom.xml
+++ b/Xml/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.5-legacy</version>
+    <version>3.2.6-legacy-SNAPSHOT</version>
   </parent>
 
   <name>Functional Genomics Platform - XML</name>

--- a/Xml/pom.xml
+++ b/Xml/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.6-legacy-SNAPSHOT</version>
+    <version>3.2.6-legacy</version>
   </parent>
 
   <name>Functional Genomics Platform - XML</name>

--- a/Xml/pom.xml
+++ b/Xml/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.4-legacy</version>
+    <version>3.2.5-legacy-SNAPSHOT</version>
   </parent>
 
   <name>Functional Genomics Platform - XML</name>

--- a/Xml/pom.xml
+++ b/Xml/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.4-legacy-SNAPSHOT</version>
+    <version>3.2.4-legacy</version>
   </parent>
 
   <name>Functional Genomics Platform - XML</name>

--- a/Xml/pom.xml
+++ b/Xml/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.5-legacy-SNAPSHOT</version>
+    <version>3.2.5-legacy</version>
   </parent>
 
   <name>Functional Genomics Platform - XML</name>

--- a/Xml/pom.xml
+++ b/Xml/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.5-SNAPSHOT</version>
+    <version>3.2.4-legacy-SNAPSHOT</version>
   </parent>
 
   <name>Functional Genomics Platform - XML</name>

--- a/Xml/pom.xml
+++ b/Xml/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>fgputil</artifactId>
-    <version>3.2.6-legacy</version>
+    <version>3.2.7-legacy-SNAPSHOT</version>
   </parent>
 
   <name>Functional Genomics Platform - XML</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <url>http://gusdb.org</url>
 
   <artifactId>fgputil</artifactId>
-  <version>3.2.5-legacy</version>
+  <version>3.2.6-legacy-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <parent>
@@ -16,7 +16,7 @@
 
   <scm>
     <developerConnection>scm:git:ssh://github.com/VEuPathDB/FgpUtil</developerConnection>
-    <tag>v3.2.5-legacy</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <url>http://gusdb.org</url>
 
   <artifactId>fgputil</artifactId>
-  <version>3.2.4-legacy-SNAPSHOT</version>
+  <version>3.2.4-legacy</version>
   <packaging>pom</packaging>
 
   <parent>
@@ -16,7 +16,7 @@
 
   <scm>
     <developerConnection>scm:git:ssh://github.com/VEuPathDB/FgpUtil</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v3.2.4-legacy</tag>
   </scm>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <url>http://gusdb.org</url>
 
   <artifactId>fgputil</artifactId>
-  <version>3.2.6-legacy</version>
+  <version>3.2.7-legacy-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <parent>
@@ -16,7 +16,7 @@
 
   <scm>
     <developerConnection>scm:git:ssh://github.com/VEuPathDB/FgpUtil</developerConnection>
-    <tag>v3.2.6-legacy</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -5,13 +5,13 @@
   <url>http://gusdb.org</url>
 
   <artifactId>fgputil</artifactId>
-  <version>3.2.5-SNAPSHOT</version>
+  <version>3.2.4-legacy-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>base-pom</artifactId>
-    <version>3.0</version>
+    <version>2.28</version>
   </parent>
 
   <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <url>http://gusdb.org</url>
 
   <artifactId>fgputil</artifactId>
-  <version>3.2.4-legacy</version>
+  <version>3.2.5-legacy-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <parent>
@@ -16,7 +16,7 @@
 
   <scm>
     <developerConnection>scm:git:ssh://github.com/VEuPathDB/FgpUtil</developerConnection>
-    <tag>v3.2.4-legacy</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <url>http://gusdb.org</url>
 
   <artifactId>fgputil</artifactId>
-  <version>3.2.6-legacy-SNAPSHOT</version>
+  <version>3.2.6-legacy</version>
   <packaging>pom</packaging>
 
   <parent>
@@ -16,7 +16,7 @@
 
   <scm>
     <developerConnection>scm:git:ssh://github.com/VEuPathDB/FgpUtil</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v3.2.6-legacy</tag>
   </scm>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <url>http://gusdb.org</url>
 
   <artifactId>fgputil</artifactId>
-  <version>3.2.5-legacy-SNAPSHOT</version>
+  <version>3.2.5-legacy</version>
   <packaging>pom</packaging>
 
   <parent>
@@ -16,7 +16,7 @@
 
   <scm>
     <developerConnection>scm:git:ssh://github.com/VEuPathDB/FgpUtil</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v3.2.5-legacy</tag>
   </scm>
 
   <repositories>

--- a/sync-module-versions.sh
+++ b/sync-module-versions.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Usage: ./sync-module-versions.sh [pom_dir]
+# Syncs all module parent versions to match the root pom version.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_POM="$SCRIPT_DIR/pom.xml"
+
+# Extract root version
+ROOT_VERSION=$(sed -n 's|.*<version>\(.*\)</version>.*|\1|p' "$ROOT_POM" | head -1)
+if [ -z "$ROOT_VERSION" ]; then
+  echo "ERROR: Could not determine root pom version" >&2
+  exit 1
+fi
+
+# Extract root artifactId
+ROOT_ARTIFACT=$(sed -n 's|.*<artifactId>\(.*\)</artifactId>.*|\1|p' "$ROOT_POM" | head -1)
+if [ -z "$ROOT_ARTIFACT" ]; then
+  echo "ERROR: Could not determine root pom artifactId" >&2
+  exit 1
+fi
+
+echo "Root: $ROOT_ARTIFACT @ $ROOT_VERSION"
+
+# Find all module poms that declare this project as parent
+find "$SCRIPT_DIR" -mindepth 2 -maxdepth 2 -name pom.xml | while read -r module_pom; do
+  # Only update if this pom references the root artifact as its parent
+  if grep -q "<artifactId>$ROOT_ARTIFACT</artifactId>" "$module_pom"; then
+    CURRENT=$(sed -n '/<parent>/,/<\/parent>/s|.*<version>\(.*\)</version>.*|\1|p' "$module_pom")
+    if [ "$CURRENT" = "$ROOT_VERSION" ]; then
+      echo "  $(dirname "$module_pom" | xargs basename): already $ROOT_VERSION"
+    else
+      sed -i "/<parent>/,/<\/parent>/s|<version>$CURRENT</version>|<version>$ROOT_VERSION</version>|" "$module_pom"
+      echo "  $(dirname "$module_pom" | xargs basename): $CURRENT -> $ROOT_VERSION"
+    fi
+  fi
+done


### PR DESCRIPTION
This is a long-term branch used to provide an FgpUtil dependency for the live sites.  The goal is to keep it up to date with master, but with hooks back to an earlier base-pom compatible with Java 11/Tomcat 6 (on RHEL 7).  It can be abandoned once the live sites -> legacy sites (on branch api-legacy-68-f) are decommissioned.